### PR TITLE
Make broadcast a true adminchat

### DIFF
--- a/SCPUtils/Functions/Functions.cs
+++ b/SCPUtils/Functions/Functions.cs
@@ -301,7 +301,7 @@ namespace SCPUtils
             {
                 if (pluginInstance.Config.BroadcastSanctions)
                 {
-                    if (admin.ReferenceHub.serverRoles.RemoteAdmin)
+                    if (admin.Sender.CheckPermission(PlayerPermissions.AdminChat))
                     {
                         admin.Broadcast(12, text, Broadcast.BroadcastFlags.AdminChat);
                     }


### PR DESCRIPTION
Currently, it gets displayed to everyone with RA access which is kind of bad in case you give RA to your donators. Why is that flag only cosmetic anyway?