### PR TITLE
Allow unwarn commands to be customized

### DIFF
--- a/SCPUtils/Commands/Unwarn.cs
+++ b/SCPUtils/Commands/Unwarn.cs
@@ -11,9 +11,9 @@ namespace SCPUtils.Commands
     internal class Unwarn : ICommand
     {
 
-        public string Command { get; } = "scputils_player_unwarn";
+        public string Command { get; } = Plugin.Singleton.Config.UnwarnCommand;
 
-        public string[] Aliases { get; } = new[] { "unwarn", "sunwarn", "su_player_unw", "su_punw", "su_puw", "scpu_player_unw", "scpu_punw", "scpu_puw" };
+        public string[] Aliases { get; } = Plugin.Singleton.Config.UnwarnCommandAliases;
 
         public string Description { get; } = "Removes a specific warning from a player!";
 

--- a/SCPUtils/Configs.cs
+++ b/SCPUtils/Configs.cs
@@ -221,6 +221,12 @@ namespace SCPUtils
 
         public List<RoleType> AllowedScps { get; private set; } = new List<RoleType>() { RoleType.Scp049, RoleType.Scp0492, RoleType.Scp079, RoleType.Scp096, RoleType.Scp106, RoleType.Scp173, RoleType.Scp93953, RoleType.Scp93989 };
 
+        [Description("The command name for the unwarn command")]
+        public string UnwarnCommand {get; set;} = "scputils_player_unwarn";
+
+        [Description("The aliases for the unwarn command")]
+        public string[] UnwarnCommandAliases {get; set;} = new[] { "unwarn", "sunwarn", "su_player_unw", "su_punw", "su_puw", "scpu_player_unw", "scpu_punw", "scpu_puw" };
+
 
         public void ConfigValidator()
         {

--- a/SCPUtils/Plugin.cs
+++ b/SCPUtils/Plugin.cs
@@ -27,6 +27,8 @@ namespace SCPUtils
 
         private static readonly ScpUtils InstanceValue = new ScpUtils();
 
+        public static Plugin Singleton = null;
+
         private ScpUtils()
         {
 
@@ -54,6 +56,8 @@ namespace SCPUtils
 
         public override void OnEnabled()
         {
+            Singleton = this;
+
             Functions = new Functions(this);
             EventHandlers = new EventHandlers(this);
             DatabasePlayerData = new Database(this);
@@ -100,6 +104,7 @@ namespace SCPUtils
             Functions.LastWarn.Clear();
             Database.LiteDatabase.Dispose();
             Harmony.UnpatchAll();
+            Singleton = null;
         }
 
 


### PR DESCRIPTION
You can do the rest of the commands and more it into translations if you want, but this command conflicts with mine and letting people customize the command info is the best solution to fix it. 